### PR TITLE
Aggregate data from multiple pages of results

### DIFF
--- a/Git.hub/Client.cs
+++ b/Git.hub/Client.cs
@@ -63,12 +63,12 @@ namespace Git.hub
 
             var request = new RestRequest("/user/repos?type=all");
 
-            var repos = client.Get<List<Repository>>(request);
-            if (repos.Data == null)
+            var repos = client.GetList<Repository>(request);
+            if (repos == null)
                 throw new Exception("Bad Credentials");
 
-            repos.Data.ForEach(r => r._client = client);
-            return repos.Data;
+            repos.ForEach(r => r._client = client);
+            return repos;
         }
 
         /// <summary>
@@ -81,9 +81,10 @@ namespace Git.hub
             var request = new RestRequest("/users/{name}/repos");
             request.AddUrlSegment("name", username);
 
-            var list = client.Get<List<Repository>>(request).Data;
+            var list = client.GetList<Repository>(request);
             if (list == null)
                 throw new InvalidOperationException("User does not exist.");
+
             list.ForEach(r => r._client = client);
             return list;
         }
@@ -119,7 +120,7 @@ namespace Git.hub
             var request = new RestRequest("/orgs/{org}/repos");
             request.AddUrlSegment("org", organization);
 
-            var list = client.Get<List<Repository>>(request).Data;
+            var list = client.GetList<Repository>(request);
 
             Organization org = new Organization { Login = organization };
             list.ForEach(r => { r._client = client; r.Organization = org; });

--- a/Git.hub/Git.hub.csproj
+++ b/Git.hub/Git.hub.csproj
@@ -47,6 +47,7 @@
     <Compile Include="Organization.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PullRequest.cs" />
+    <Compile Include="RestClientExtensions.cs" />
     <Compile Include="util\ReplacingJsonSerializer.cs" />
     <Compile Include="Repository.cs" />
     <Compile Include="User.cs" />

--- a/Git.hub/Issue.cs
+++ b/Git.hub/Issue.cs
@@ -21,7 +21,7 @@ namespace Git.hub
             request.AddUrlSegment("repo", Repository.Name);
             request.AddUrlSegment("issue", Number.ToString());
 
-            return _client.Get<List<IssueComment>>(request).Data;
+            return _client.GetList<IssueComment>(request);
         }
 
         public IssueComment CreateComment(string body)

--- a/Git.hub/PullRequest.cs
+++ b/Git.hub/PullRequest.cs
@@ -86,7 +86,7 @@ namespace Git.hub
             request.AddUrlSegment("repo", Repository.Name);
             request.AddUrlSegment("pull", Number.ToString());
 
-            return _client.Get<List<PullRequestCommit>>(request).Data;
+            return _client.GetList<PullRequestCommit>(request);
         }
 
         public Issue ToIssue()

--- a/Git.hub/Repository.cs
+++ b/Git.hub/Repository.cs
@@ -84,7 +84,7 @@ namespace Git.hub
             request.AddUrlSegment("user", Owner.Login);
             request.AddUrlSegment("repo", Name);
 
-            return _client.Get<List<Branch>>(request).Data;
+            return _client.GetList<Branch>(request);
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace Git.hub
             request.AddUrlSegment("user", Owner.Login);
             request.AddUrlSegment("repo", Name);
 
-            var list = _client.Get<List<PullRequest>>(request).Data;
+            var list = _client.GetList<PullRequest>(request);
             if (list == null)
                 return null;
 

--- a/Git.hub/RestClientExtensions.cs
+++ b/Git.hub/RestClientExtensions.cs
@@ -1,0 +1,46 @@
+﻿namespace Git.hub
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+    using RestSharp;
+
+    internal static class RestClientExtensions
+    {
+        private static readonly Regex LinkHeaderFormat = new Regex(@"<(?<Link>[^>]*)>; rel=""(?<Rel>\w*)""", RegexOptions.Compiled);
+
+        public static List<T> GetList<T>(this IRestClient client, IRestRequest request)
+        {
+            List<T> result = new List<T>();
+            while (true)
+            {
+                IRestResponse<List<T>> pageResponse = client.Get<List<T>>(request);
+                if (pageResponse.Data == null)
+                    return null;
+
+                result.AddRange(pageResponse.Data);
+
+                Parameter linkHeader = pageResponse.Headers.FirstOrDefault(i => string.Equals(i.Name, "Link", StringComparison.OrdinalIgnoreCase));
+                if (linkHeader == null)
+                    break;
+
+                bool hasNext = false;
+                foreach (Match match in LinkHeaderFormat.Matches(linkHeader.Value.ToString()))
+                {
+                    if (string.Equals(match.Groups["Rel"].Value, "next", StringComparison.OrdinalIgnoreCase))
+                    {
+                        request = new RestRequest(new Uri(match.Groups["Link"].Value));
+                        hasNext = true;
+                        break;
+                    }
+                }
+
+                if (!hasNext)
+                    break;
+            }
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
The current library fails to return all results for some calls. In particular, the `getRepositories()` method fails to return all repositories for users with a large numbers of repositories (even my account has too many repositories). As a result, other libraries which depend on the result of these methods, such as GitExtensions' Clone Github Repository feature, fail to behave properly.

For API calls that result in a `List<T>`, check the HTTP headers for a `Link` header with a link marked with `rel="next"`. For these cases, include the results of the following pages in the returned list.

I implemented this via a helper extension method `GetList` to aid in conversion of multiple methods that return lists.
